### PR TITLE
Add character length helper text to title field

### DIFF
--- a/src/SEO.php
+++ b/src/SEO.php
@@ -18,6 +18,13 @@ class SEO
                 'title' => TextInput::make('title')
                     ->translateLabel()
                     ->label(__('filament-seo::translations.title'))
+                    ->helperText(function (?string $state): string {
+                        return (string) Str::of(strlen($state))
+                            ->append(' / ')
+                            ->append(60 . ' ')
+                            ->append(Str::of(__('filament-seo::translations.characters'))->lower());
+                    })
+                    ->reactive()
                     ->columnSpan(2),
                 'author' => TextInput::make('author')
                     ->translateLabel()


### PR DESCRIPTION
This PR adds the helper text character limit to title field as a visual indicator. To avoid Google rewriting titles to fit the users screen in the search index, the advised limit should be between 50-60 characters. This change does not impose these guidelines or restrict the titles given, it is merely a visual indicator to help direct the admin user.